### PR TITLE
feat: Add CommonJS compatibility for dual module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,24 @@
 {
   "name": "@delandlabs/ic-dev-kit",
-  "version": "2.4.2-pocket-ic",
+  "version": "2.4.2-commonjs-compat",
   "description": "",
   "type": "module",
   "source": "src/src/index.ts",
+  "main": "dist/commonjs-package/src/src/index.js",
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/module.js",
+      "require": "./dist/commonjs-package/src/src/index.js",
+      "types": "./dist/types.d.ts"
+    }
+  },
   "scripts": {
     "test": "lint-staged",
-    "pack-dist": "rm -rf dist/ && vite build",
+    "pack-dist": "rm -rf dist/ && npm run build:esm && npm run build:cjs",
+    "build:esm": "vite build",
+    "build:cjs": "tsc --project tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/commonjs-package/package.json",
     "pack-docs": "rm -rf docs/  && typedoc src/src/",
     "build": "npm run pack-dist",
     "prepublishOnly": "npm test  &&  npm run build",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "./dist/commonjs-package",
+    "declaration": true,
+    "declarationDir": "./dist/commonjs-package",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules/**/*",
+    ".webpack/**/*", 
+    "_warmup/**/*",
+    ".vscode/**/*",
+    "dist/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add dual module system support enabling both ES modules and CommonJS compatibility
- Configure separate build outputs for ES modules (`dist/module.js`) and CommonJS (`dist/commonjs-package/`)
- Update package.json exports to automatically route imports/requires to correct module format
- Maintain full backward compatibility with existing ES module consumers

## Technical Implementation
- **ES Module Build**: Uses existing Vite build → `dist/module.js`
- **CommonJS Build**: New TypeScript compilation → `dist/commonjs-package/src/src/index.js`
- **Package Exports**: Automatic module system detection via `package.json` exports field
- **Isolated Package**: CommonJS output includes separate `package.json` with `"type": "commonjs"`

## Compatibility Matrix
| Module System | Import Statement | Entry Point |
|---------------|------------------|-------------|
| ES Modules | `import { identity } from '@delandlabs/ic-dev-kit'` | `dist/module.js` |
| CommonJS | `const { identity } = require('@delandlabs/ic-dev-kit')` | `dist/commonjs-package/src/src/index.js` |

## Test Results
✅ ES module import compatibility verified
✅ CommonJS require compatibility verified  
✅ All core functions (identity, canister, utils) accessible
✅ pocket-ic dynamic port detection working in both formats
✅ Backward compatibility maintained

## Use Case
This enables IC Naming project and other CommonJS-based projects to use the latest ic-dev-kit version (2.4.2+) without module system conflicts, while preserving full compatibility for existing ES module consumers.

🤖 Generated with [Claude Code](https://claude.ai/code)