### PR TITLE
fix: Downgrade rimraf to v5 for Node.js 18 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lint-staged": "13.0.3",
     "open-cli": "7.0.1",
     "prettier": "^3.5.3",
-    "rimraf": "^6.0.1",
+    "rimraf": "^5.0.10",
     "ts-jest": "28.0.7",
     "typedoc": "0.23.8",
     "typedoc-plugin-mdn-links": "2.0.0",


### PR DESCRIPTION
## Summary
Fix CI build failure caused by rimraf v6 Node.js version incompatibility.

## Problem
- rimraf v6.0.1 requires Node.js 20 or >=22
- CI environment uses Node.js 18.20.8
- Build fails with: `The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.20.8"`

## Solution
- Downgrade rimraf from v6.0.1 to v5.0.10
- rimraf v5 supports Node.js 14+ (compatible with Node.js 18)
- Maintains all cross-platform file removal functionality
- No breaking changes to build scripts

## Test Results
✅ Build succeeds with rimraf v5.0.10
✅ Cross-platform compatibility maintained
✅ All npm scripts work correctly

## Impact
- Fixes CI build failures
- Maintains compatibility with existing Node.js 18 environments
- No functional changes to package behavior

🤖 Generated with [Claude Code](https://claude.ai/code)